### PR TITLE
Added comments for users that can't use systemctl.

### DIFF
--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -9,6 +9,9 @@
 #
 # See README.md for more information.
 
+# If you are on Void Linux, replace "systemctl" with "loginctl", since "systemctl"
+# is not available in that distribution.
+
 set -e
 set -u
 
@@ -41,10 +44,10 @@ declare -A actions
 actions[lockscreen]="loginctl lock-session ${XDG_SESSION_ID-}"
 #actions[switchuser]="???"
 actions[logout]="loginctl terminate-session ${XDG_SESSION_ID-}"
-actions[suspend]="systemctl suspend"
-actions[hibernate]="systemctl hibernate"
-actions[reboot]="systemctl reboot"
-actions[shutdown]="systemctl poweroff"
+actions[suspend]="systemctl suspend" # Replace "systemctl" with "loginctl" in Void Linux
+actions[hibernate]="systemctl hibernate" # Replace "systemctl" with "loginctl" in Void Linux
+actions[reboot]="systemctl reboot" # Replace "systemctl" with "loginctl" in Void Linux
+actions[shutdown]="systemctl poweroff" # Replace "systemctl" with "loginctl" in Void Linux
 
 # By default, ask for confirmation for actions that are irreversible
 confirmations=(reboot shutdown logout)

--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -9,8 +9,8 @@
 #
 # See README.md for more information.
 
-# If you are on Void Linux, replace "systemctl" with "loginctl", since "systemctl"
-# is not available in that distribution.
+# If you are on Void Linux, replace "systemctl" with "loginctl", otherwise the
+# script won't work.
 
 set -e
 set -u


### PR DESCRIPTION
As a Void Linux user, I had problems using this script.
By browsing this repo's issues, I have discovered that you can't use systemctl on Void Linux (I am a new Linux user so I didn't know that). For this reason, I added comments to help people like me who don't know about these details to encourage them to use loginctl as an alternative, which works without any problem.