### PR TITLE
Fix obsolete icon codepoints

### DIFF
--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -29,11 +29,11 @@ texts[shutdown]="shut down"
 
 declare -A icons
 icons[lockscreen]="\uf023"
-icons[switchuser]="\uf518"
-icons[logout]="\uf842"
-icons[suspend]="\uf9b1"
-icons[hibernate]="\uf7c9"
-icons[reboot]="\ufc07"
+icons[switchuser]="\Uf0019"
+icons[logout]="\Uf0343"
+icons[suspend]="\Uf04b2"
+icons[hibernate]="\Uf02ca"
+icons[reboot]="\Uf0709"
 icons[shutdown]="\uf011"
 icons[cancel]="\u00d7"
 


### PR DESCRIPTION
With Nerd Fonts v2.3.0, some of the icons used here have been moved to different codepoints to avoid collision with other characters. The old codepoints are still usable at the moment, but will be removed entirely with Nerd Fonts v3 and depending on local font configuration may not work correctly now.

This replaces the old codepoints with their equivalents in the newly allocated space, users with a reasonably up to date patched font should notice no change.

See ryanoasis/nerd-fonts#365 for more details.