### PR TITLE
Add custom command option

### DIFF
--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -68,7 +68,7 @@ function check_valid {
 }
 
 # Parse command-line options
-parsed=$(getopt --options=h --longoptions=help,dry-run,confirm:,choices:,choose:,symbols,no-symbols,text,no-text,symbols-font: --name "$0" -- "$@")
+parsed=$(getopt --options=h --longoptions=help,dry-run,confirm:,choices:,choose:,symbols,no-symbols,text,no-text,symbols-font:,custom-command: --name "$0" -- "$@")
 if [ $? -ne 0 ]; then
     echo 'Terminating...' >&2
     exit 1
@@ -153,6 +153,11 @@ while true; do
             ;;
         "--symbols-font")
             symbols_font="$2"
+            shift 2
+            ;;
+        "--custom-command")
+            IFS='=' read -r operation command <<<"$2"
+            actions[$operation]="$command"
             shift 2
             ;;
         "--")


### PR DESCRIPTION
Allow user to specify what command to run on which operation. 
Example:
```bash
rofi -show power-menu -modi power-menu:"rofi-power-menu --custom-command \"lockscreen=xautolock -locknow\""
```