### PR TITLE
use `loginctl kill-session` for logging out

### DIFF
--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -40,7 +40,7 @@ icons[cancel]="\Uf0156"
 declare -A actions
 actions[lockscreen]="loginctl lock-session ${XDG_SESSION_ID-}"
 #actions[switchuser]="???"
-actions[logout]="loginctl terminate-session ${XDG_SESSION_ID-}"
+actions[logout]="loginctl kill-session ${XDG_SESSION_ID-}"
 actions[suspend]="systemctl suspend"
 actions[hibernate]="systemctl hibernate"
 actions[reboot]="systemctl reboot"


### PR DESCRIPTION
Commit changes logout command to gracefully terminate session using a signal only. This should prevent issues with greeters associated with a given user session becoming broken after logout.

New method successfully tested with SwayWM. More feedback for other window managers is welcome.

See https://github.com/jluttine/rofi-power-menu/issues/22.
