### PR TITLE
FIX: confirmation- and regular message name collision with --no-text option enabled causing an unbreakable loop when confirming the selected action

### DIFF
--- a/rofi-power-menu
+++ b/rofi-power-menu
@@ -208,7 +208,9 @@ do
 done
 for entry in "${all[@]}"
 do
-    confirmationMessages[$entry]=$(write_message "${icons[$entry]}" "Yes, ${texts[$entry]}")
+    # Add zero-width space character (\u200b) to icon to ensure confirmation-
+    # and regular messages never collide.
+    confirmationMessages[$entry]=$(write_message "${icons[$entry]}\u200b" "Yes, ${texts[$entry]}")
 done
 confirmationMessages[cancel]=$(write_message "${icons[cancel]}" "No, cancel")
 


### PR DESCRIPTION
### Bug

Running the rofi-power-menu script with the `--no-text` option enabled breaks actions that require confirmation.

Instead of proceeding with the action following confirmation, the confirmation menu respawns again and again.

Cancellation, however, does work.

### Cause

The bash script creates two associative arrays: `messages` and `confirmationMessages`.

When the `--no-text` option is enabled, the entries in both arrays contain only the icons associated with each action.
I.e. the messages between the two arrays are identical.

At the old line 242, the user selection is compared against the entries in `messages`.
On a match, the script returns the input for a confirmation dialogue, if necessary.

The script is run in its entirety on every user-input, meaning that the same if-statement at old line 242 is evaluated on user-input from the confirmation dialogue. When the user confirms the action by selecting the presented item from the `confirmationMessages` array and that item is identical to an item in the `messages` array, then the if-statement triggers again and repeats its the behavior of its last execution, returning input for a confirmation dialogue.

This creates a loop that cannot be broken by confirming the action.

### Fix

This PR adds a zero-width-space (ZWSP) character to all the icons in the `confirmationMessages` array, but not the ones in the `messages` array. This ensures that icons alone will never collide between the two arrays, without altering visual appearance.

Text doesn't collide anyway, because the confirmation-messages are already prepared with unique text compared to the message counterparts in the `messages` array.